### PR TITLE
Remove deprecated argument from const definitions

### DIFF
--- a/libraries/highlight.php
+++ b/libraries/highlight.php
@@ -236,7 +236,7 @@ function syntax_highlight_helper($text, $language)
     "try",          "typeof",       "uint",     "ulong",        "unchecked",
     "unsafe",       "ushort",       "using",    "virtual",      "volatile",
     "void",         "while"),
-    
+
     "Ruby" => array(
     "alias",        "and",          "begin",    "break",        "case",
     /*class*/       "def",          "defined",  "do",           "else",
@@ -275,12 +275,12 @@ function syntax_highlight_helper($text, $language)
         ),
 
     "PL/I" => array(
-    "A",            "ABS",            "ACOS",        "%ACTIVATE",    "ACTUALCOUNT", 
-    "ADD",            "ADDR",            "ADDREL",    "ALIGNED",        "ALLOCATE", 
-    "ALLOC",        "ALLOCATION",    "ALLOCN",    "ANY",            "ANYCONDITION", 
-    "APPEND",        "AREA",            "ASIN",        "ATAN",            "ATAND", 
-    "ATANH",        "AUTOMATIC",    "AUTO",        "B",            "B1", 
-    "B2",            "B3",            "B4",        "BACKUP_DATE",    "BASED", 
+    "A",            "ABS",            "ACOS",        "%ACTIVATE",    "ACTUALCOUNT",
+    "ADD",            "ADDR",            "ADDREL",    "ALIGNED",        "ALLOCATE",
+    "ALLOC",        "ALLOCATION",    "ALLOCN",    "ANY",            "ANYCONDITION",
+    "APPEND",        "AREA",            "ASIN",        "ATAN",            "ATAND",
+    "ATANH",        "AUTOMATIC",    "AUTO",        "B",            "B1",
+    "B2",            "B3",            "B4",        "BACKUP_DATE",    "BASED",
     "BATCH",        "BEGIN",        "BINARY",    "BIN",            "BIT",
     "BLOCK_BOUNDARY_FORMAT",        "BLOCK_IO",    "BLOCK_SIZE",    "BOOL",
     "BUCKET_SIZE",    "BUILTIN",        "BY",        "BYTE",            "BYTESIZE",
@@ -355,7 +355,7 @@ function syntax_highlight_helper($text, $language)
     "UFL",            "UNION",        "UNSPEC",    "UNTIL",        "UPDATE",
     "USER_OPEN",    "VALID",        "VALUE",    "VAL",            "VARIABLE",
     "VARIANT",        "VARYING",        "VAR",        "VAXCONDITION",    "VERIFY",
-    "WAIT_FOR_RECORD",                "%WARN",    "WARN",            "WHEN",    
+    "WAIT_FOR_RECORD",                "%WARN",    "WARN",            "WHEN",
     "WHILE",        "WORLD_PROTECTION",            "WRITE",        "WRITE_BEHIND",
     "WRITE_CHECK",    "X",            "ZERODIVIDE"),
 
@@ -571,10 +571,10 @@ function lparen_putback_rtrim1($span, $lang, $ch)
     return rtrim1('(' . $span, $lang, $ch);
 }
 
-function prepend_xml_opentag($span, $lang, $ch) 
-{                                               
+function prepend_xml_opentag($span, $lang, $ch)
+{
     return '<span class="xml_tag">&lt;' . $span;
-}                                               
+}
 
 function proc_void($span, $lang, $ch)
 {
@@ -591,31 +591,31 @@ function syntax_highlight($text, $language)
 {
     if ($language == "Plain Text") return $text;
 
-    define("normal_text",   1, true);
-    define("dq_literal",    2, true);
-    define("dq_escape",     3, true);
-    define("sq_literal",    4, true);
-    define("sq_escape",     5, true);
-    define("slash_begin",   6, true);
-    define("star_comment",  7, true);
-    define("star_end",      8, true);
-    define("line_comment",  9, true);
-    define("html_entity",  10, true);
-    define("lc_escape",    11, true);
-    define("block_comment",12, true);
-    define("paren_begin",  13, true);
-    define("dash_begin",   14, true);
-    define("bt_literal",   15, true);
-    define("bt_escape",    16, true);
-    define("xml_tag_begin",17, true);
-    define("xml_tag",      18, true);
-    define("xml_pi",       19, true);
-    define("sch_normal",   20, true);
-    define("sch_stresc",    21, true);
-    define("sch_idexpr",   22, true);
-    define("sch_numlit",   23, true);
-    define("sch_chrlit",   24, true);
-    define("sch_strlit",   25, true);
+    define("normal_text",   1);
+    define("dq_literal",    2);
+    define("dq_escape",     3);
+    define("sq_literal",    4);
+    define("sq_escape",     5);
+    define("slash_begin",   6);
+    define("star_comment",  7);
+    define("star_end",      8);
+    define("line_comment",  9);
+    define("html_entity",  10);
+    define("lc_escape",    11);
+    define("block_comment",12);
+    define("paren_begin",  13);
+    define("dash_begin",   14);
+    define("bt_literal",   15);
+    define("bt_escape",    16);
+    define("xml_tag_begin",17);
+    define("xml_tag",      18);
+    define("xml_pi",       19);
+    define("sch_normal",   20);
+    define("sch_stresc",   21);
+    define("sch_idexpr",   22);
+    define("sch_numlit",   23);
+    define("sch_chrlit",   24);
+    define("sch_strlit",   25);
 
     $initial_state["Scheme"] = sch_normal;
 
@@ -820,32 +820,32 @@ function syntax_highlight($text, $language)
     $sql[lc_escape]["\r"]      = lc_escape;
     $sql[lc_escape][0]         = line_comment;
 
-    $xml[normal_text]["<"]     = xml_tag_begin;               
-    $xml[normal_text]["&"]     = html_entity;                 
-    $xml[normal_text][0]       = normal_text;                 
-    $xml[html_entity][";"]     = normal_text;                 
+    $xml[normal_text]["<"]     = xml_tag_begin;
+    $xml[normal_text]["&"]     = html_entity;
+    $xml[normal_text][0]       = normal_text;
+    $xml[html_entity][";"]     = normal_text;
     $xml[html_entity]["<"]     = xml_tag_begin;
-    $xml[html_entity][0]       = html_entity;                 
-    $xml[xml_tag_begin]["?"]   = xml_pi;                      
-    $xml[xml_tag_begin]["!"]   = line_comment;                
-    $xml[xml_tag_begin][0]     = xml_tag;                     
-    $xml[xml_tag][">"]         = normal_text;                 
-    $xml[xml_tag]["\""]        = dq_literal;           
-    $xml[xml_tag]["'"]         = sq_literal;                   
-    $xml[xml_tag][0]           = xml_tag;                     
-    $xml[xml_pi][">"]          = normal_text;                 
-    $xml[xml_pi][0]            = xml_tag;                     
-    $xml[line_comment][">"]    = normal_text;                 
-    $xml[line_comment][0]      = line_comment;                
-    $xml[dq_literal]["\""]     = xml_tag;                     
-    $xml[dq_literal]["&"]      = dq_escape;                   
-    $xml[dq_literal][0]        = dq_literal;                  
-    $xml[sq_literal]["'"]      = xml_tag;                     
-    $xml[sq_literal]["&"]      = sq_escape;                   
-    $xml[sq_literal][0]        = sq_literal;                  
-    $xml[dq_escape][";"]       = dq_literal;                  
-    $xml[dq_escape][0]         = dq_escape;                   
-    
+    $xml[html_entity][0]       = html_entity;
+    $xml[xml_tag_begin]["?"]   = xml_pi;
+    $xml[xml_tag_begin]["!"]   = line_comment;
+    $xml[xml_tag_begin][0]     = xml_tag;
+    $xml[xml_tag][">"]         = normal_text;
+    $xml[xml_tag]["\""]        = dq_literal;
+    $xml[xml_tag]["'"]         = sq_literal;
+    $xml[xml_tag][0]           = xml_tag;
+    $xml[xml_pi][">"]          = normal_text;
+    $xml[xml_pi][0]            = xml_tag;
+    $xml[line_comment][">"]    = normal_text;
+    $xml[line_comment][0]      = line_comment;
+    $xml[dq_literal]["\""]     = xml_tag;
+    $xml[dq_literal]["&"]      = dq_escape;
+    $xml[dq_literal][0]        = dq_literal;
+    $xml[sq_literal]["'"]      = xml_tag;
+    $xml[sq_literal]["&"]      = sq_escape;
+    $xml[sq_literal][0]        = sq_literal;
+    $xml[dq_escape][";"]       = dq_literal;
+    $xml[dq_escape][0]         = dq_escape;
+
     //
     // Main state transition table
     //
@@ -1036,15 +1036,15 @@ function syntax_highlight($text, $language)
     $edges["XML"][xml_tag . "," . normal_text] = '&gt;</span>';
     $edges["XML"][xml_tag_begin . "," . xml_pi] = '<span class="xml_pi">&lt;?';
     $edges["XML"][xml_tag_begin . "," . line_comment] = '<span class="comment">&lt;!';
-    $edges["XML"][line_comment . "," . normal_text] = '&gt;</span>'; 
+    $edges["XML"][line_comment . "," . normal_text] = '&gt;</span>';
     $edges["XML"][xml_tag .",". dq_literal]   = '<span class="literal">"';
     $edges["XML"][dq_literal . "," . xml_tag] = '"</span>';
     $edges["XML"][dq_literal . "," . dq_escape] = '<span class="html_entity">&amp;';
     $edges["XML"][dq_escape . "," . dq_literal] = '</span>';
     $edges["XML"][xml_tag .",". sq_literal]   = '<span class="literal">\'';
     $edges["XML"][sq_literal . "," . xml_tag] = '\'</span>';
-    $edges["XML"][sq_literal . "," . sq_escape] = '<span class="html_entity">&amp;'; 
-    $edges["XML"][sq_escape . "," . sq_literal] = '</span>'; 
+    $edges["XML"][sq_literal . "," . sq_escape] = '<span class="html_entity">&amp;';
+    $edges["XML"][sq_escape . "," . sq_literal] = '</span>';
 
     //
     // The State Machine
@@ -1107,8 +1107,6 @@ function syntax_highlight($text, $language)
             array_key_exists("$state," . normal_text, $edges[$language]))
             $output .= $edges[$language]["$state," . normal_text];
     }
-                
+
     return $output;
 }
-
-?>


### PR DESCRIPTION
The third argument, `case_insensitive`, to the `define` function was deprecated in PHP 7.3.0 and generates a warning in PHP 8.0.0+. This commit removes the argument, to prevent spurious warnings. It also removes trailing whitespace and the PHP close tag at the end of the file, in line with best practice.